### PR TITLE
feat: add brand asset copy actions

### DIFF
--- a/app/brand/_components/brand-assets.tsx
+++ b/app/brand/_components/brand-assets.tsx
@@ -1,6 +1,8 @@
 import Image from "next/image";
 import { Download } from "lucide-react";
 
+import { CopyAssetButton } from "./copy-asset-button";
+
 type DownloadAsset = {
   format: "SVG" | "PNG";
   href: string;
@@ -107,9 +109,16 @@ export function AssetPanel({
         <span className="min-w-0 truncate font-code text-[11px] tracking-normal text-white/55">
           {downloads[0]?.href.replace("/brand/", "")}
         </span>
-        <div className="flex shrink-0 gap-2">
+        <div className="flex flex-wrap gap-2 sm:justify-end">
           {downloads.map((asset) => (
-            <DownloadLink asset={asset} compact key={asset.href} />
+            <div className="inline-flex shrink-0" key={asset.href}>
+              <DownloadLink asset={asset} compact />
+              <CopyAssetButton
+                format={asset.format}
+                href={asset.href}
+                label={asset.label}
+              />
+            </div>
           ))}
         </div>
       </div>

--- a/app/brand/_components/copy-asset-button.tsx
+++ b/app/brand/_components/copy-asset-button.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Check, CircleAlert, Copy, LoaderCircle } from "lucide-react";
+
+type CopyAssetButtonProps = {
+  format: "SVG" | "PNG";
+  href: string;
+  label: string;
+};
+
+type CopyStatus = "idle" | "copying" | "copied" | "copied-link" | "error";
+
+const resetDelay = 2000;
+
+function getAssetName(label: string) {
+  return label.replace(/^Download /, "").replace(/ as (SVG|PNG)$/, "");
+}
+
+async function fetchAsset(href: string) {
+  const response = await fetch(href);
+
+  if (!response.ok) {
+    throw new Error(`Unable to fetch ${href}`);
+  }
+
+  return response;
+}
+
+function canWriteClipboardItem(mimeType: string) {
+  return (
+    typeof ClipboardItem !== "undefined" &&
+    typeof navigator.clipboard.write === "function" &&
+    (typeof ClipboardItem.supports !== "function" ||
+      ClipboardItem.supports(mimeType))
+  );
+}
+
+async function copyAsset(format: "SVG" | "PNG", href: string) {
+  if (!navigator.clipboard) {
+    throw new Error("Clipboard access is unavailable");
+  }
+
+  if (format === "SVG") {
+    const markup = fetchAsset(href).then((response) => response.text());
+
+    if (canWriteClipboardItem("text/plain")) {
+      try {
+        await navigator.clipboard.write([
+          new ClipboardItem({ "text/plain": markup }),
+        ]);
+        return "copied" as const;
+      } catch {
+        // Fall through to writeText for browsers with partial ClipboardItem support.
+      }
+    }
+
+    await navigator.clipboard.writeText(await markup);
+    return "copied" as const;
+  }
+
+  if (canWriteClipboardItem("image/png")) {
+    const image = fetchAsset(href).then(async (response) => {
+      const blob = await response.blob();
+
+      if (blob.type === "image/png") {
+        return blob;
+      }
+
+      return new Blob([await blob.arrayBuffer()], { type: "image/png" });
+    });
+
+    try {
+      await navigator.clipboard.write([
+        new ClipboardItem({ "image/png": image }),
+      ]);
+      return "copied" as const;
+    } catch {
+      // Fall through to a link when the browser rejects binary clipboard data.
+    }
+  }
+
+  await navigator.clipboard.writeText(
+    new URL(href, window.location.origin).toString(),
+  );
+  return "copied-link" as const;
+}
+
+export function CopyAssetButton({
+  format,
+  href,
+  label,
+}: CopyAssetButtonProps) {
+  const [status, setStatus] = useState<CopyStatus>("idle");
+  const isMounted = useRef(true);
+  const resetTimer = useRef<number | null>(null);
+  const assetName = getAssetName(label);
+  const copyLabel =
+    format === "SVG"
+      ? `Copy ${assetName} SVG markup`
+      : `Copy ${assetName} PNG image`;
+
+  useEffect(() => {
+    isMounted.current = true;
+
+    return () => {
+      isMounted.current = false;
+
+      if (resetTimer.current !== null) {
+        window.clearTimeout(resetTimer.current);
+      }
+    };
+  }, []);
+
+  function resetAfterDelay() {
+    if (resetTimer.current !== null) {
+      window.clearTimeout(resetTimer.current);
+    }
+
+    resetTimer.current = window.setTimeout(() => {
+      setStatus("idle");
+      resetTimer.current = null;
+    }, resetDelay);
+  }
+
+  async function handleCopy() {
+    if (resetTimer.current !== null) {
+      window.clearTimeout(resetTimer.current);
+      resetTimer.current = null;
+    }
+
+    setStatus("copying");
+
+    try {
+      const nextStatus = await copyAsset(format, href);
+
+      if (!isMounted.current) {
+        return;
+      }
+
+      setStatus(nextStatus);
+    } catch {
+      if (!isMounted.current) {
+        return;
+      }
+
+      setStatus("error");
+    }
+
+    resetAfterDelay();
+  }
+
+  const title =
+    status === "copying"
+      ? `Copying ${format}...`
+      : status === "copied"
+        ? format === "SVG"
+          ? "SVG markup copied"
+          : "PNG image copied"
+        : status === "copied-link"
+          ? "PNG link copied"
+          : status === "error"
+            ? `Could not copy ${format}`
+            : copyLabel;
+
+  const statusMessage =
+    status === "copied" || status === "copied-link" || status === "error"
+      ? title
+      : "";
+
+  return (
+    <>
+      <button
+        aria-label={copyLabel}
+        className="relative -ml-px inline-flex size-10 shrink-0 items-center justify-center border border-white/20 bg-white/[0.04] text-white/65 transition-[background-color,border-color,color] duration-150 hover:z-10 hover:border-white/45 hover:bg-white/[0.09] hover:text-white focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#f5f5f2] focus-visible:ring-offset-2 focus-visible:ring-offset-[#080808] disabled:cursor-wait disabled:text-white/42"
+        data-state={status}
+        disabled={status === "copying"}
+        onClick={handleCopy}
+        title={title}
+        type="button"
+      >
+        {status === "copying" ? (
+          <LoaderCircle
+            aria-hidden="true"
+            className="size-3.5 animate-spin motion-reduce:animate-none"
+            strokeWidth={1.8}
+          />
+        ) : status === "copied" || status === "copied-link" ? (
+          <Check aria-hidden="true" className="size-3.5" strokeWidth={1.8} />
+        ) : status === "error" ? (
+          <CircleAlert
+            aria-hidden="true"
+            className="size-3.5"
+            strokeWidth={1.8}
+          />
+        ) : (
+          <Copy aria-hidden="true" className="size-3.5" strokeWidth={1.8} />
+        )}
+      </button>
+      <span aria-live="polite" className="sr-only" role="status">
+        {statusMessage}
+      </span>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

- pair each SVG and PNG download with a compact copy action
- copy SVG markup directly and PNG image data when the browser supports it
- fall back to copying the PNG asset URL when binary clipboard writes are unavailable
- provide accessible loading, success, and error feedback without shifting the layout
- allow the grouped controls to wrap cleanly on narrower asset cards

## Why

Brand assets can now be reused directly from the brand page without downloading and reopening each file first.

## Validation

- `./node_modules/.bin/eslint app/brand/_components/brand-assets.tsx app/brand/_components/copy-asset-button.tsx`
- `./node_modules/.bin/tsc --noEmit`
- `npm run build`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add compact Copy buttons next to SVG/PNG downloads on brand asset cards. Users can copy SVG markup or PNG image data (fallback to URL) with accessible feedback and no layout shift.

- **New Features**
  - Adds `CopyAssetButton` beside each `DownloadLink` in `AssetPanel`.
  - For SVG, copies markup as text; for PNG, writes image data when supported or copies the asset URL.
  - Shows copying/success/error states with icons and SR-only updates; button disables during copy and resets after 2s.
  - Keeps controls compact and allows wrapping on narrow cards.

<sup>Written for commit b9e2ad8ee6a32266187702aae8639531d29d69b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/web/pull/8?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

